### PR TITLE
Database migration for news and academic units

### DIFF
--- a/src/main/java/uap/edu/bo/cpeyfc/domain/aca_unidad/AcaUnidad.java
+++ b/src/main/java/uap/edu/bo/cpeyfc/domain/aca_unidad/AcaUnidad.java
@@ -1,0 +1,46 @@
+package uap.edu.bo.cpeyfc.domain.aca_unidad;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.FieldNameConstants;
+import org.hibernate.annotations.ColumnDefault;
+import uap.edu.bo.cpeyfc.config.Auditoria;
+
+/**
+ * Entidad: aca_unidad
+ * Descripción: Catálogo de unidades académicas y administrativas de la institución
+ */
+@FieldNameConstants
+@Getter
+@Setter
+@Entity
+@Table(name = "aca_unidad")
+public class AcaUnidad extends Auditoria {
+
+  /**
+   * ID de la unidad académica
+   */
+  @Id
+  @ColumnDefault("nextval('aca_unidad_id_aca_unidad_seq')")
+  @Column(name = "id_aca_unidad", nullable = false)
+  private Integer idAcaUnidad;
+
+  /**
+   * Nombre de la unidad (Ej: Escuela Técnica, Gabinete Psicopedagógico)
+   */
+  @Column(name = "nombre_unidad", nullable = false, length = 100)
+  private String nombreUnidad;
+
+  /**
+   * Descripción opcional de la unidad
+   */
+  @Column(name = "descripcion", columnDefinition = "TEXT")
+  private String descripcion;
+
+  /**
+   * Estado de la unidad (ACTIVO, ELIMINADO)
+   */
+  @Column(name = "estado_unidad", nullable = false, length = 35)
+  private String estadoUnidad;
+}

--- a/src/main/java/uap/edu/bo/cpeyfc/domain/aca_unidad/AcaUnidadRepository.java
+++ b/src/main/java/uap/edu/bo/cpeyfc/domain/aca_unidad/AcaUnidadRepository.java
@@ -1,0 +1,41 @@
+package uap.edu.bo.cpeyfc.domain.aca_unidad;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Repositorio: AcaUnidadRepository
+ * Descripción: Gestión de unidades académicas y administrativas
+ */
+public interface AcaUnidadRepository extends JpaRepository<AcaUnidad, Integer> {
+
+  /**
+   * Vista: Listado de unidades académicas activas con conteo de noticias
+   *
+   * @return Lista de unidades activas con estadísticas de noticias
+   */
+  @Query(nativeQuery = true, value = "SELECT * FROM vista_unidades_activas")
+  List<Map<String, Object>> vistaUnidadesActivas();
+
+  /**
+   * Función: fn_registrar_unidad
+   * Registra una nueva unidad académica/administrativa
+   *
+   * @param p_nombre_unidad Nombre de la unidad
+   * @param p_descripcion   Descripción opcional
+   * @param p_user_reg      ID del usuario que registra
+   * @return Mensaje de confirmación con el ID generado
+   */
+  @Query(value = """
+        SELECT fn_registrar_unidad(
+            :p_nombre_unidad,
+            :p_descripcion,
+            :p_user_reg)
+        """, nativeQuery = true)
+  String registrarUnidad(String p_nombre_unidad,
+                         String p_descripcion,
+                         Integer p_user_reg);
+}

--- a/src/main/java/uap/edu/bo/cpeyfc/domain/pub_noticia/PubNoticia.java
+++ b/src/main/java/uap/edu/bo/cpeyfc/domain/pub_noticia/PubNoticia.java
@@ -1,0 +1,93 @@
+package uap.edu.bo.cpeyfc.domain.pub_noticia;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.experimental.FieldNameConstants;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+import uap.edu.bo.cpeyfc.config.Auditoria;
+import uap.edu.bo.cpeyfc.domain.aca_unidad.AcaUnidad;
+
+import java.time.LocalDate;
+
+/**
+ * Entidad: pub_noticia
+ * Descripción: Noticias institucionales publicadas en carrusel web
+ */
+@FieldNameConstants
+@Getter
+@Setter
+@Entity
+@Table(name = "pub_noticia", indexes = {
+    @Index(name = "fk_pub_noticia_unidad", columnList = "id_aca_unidad")
+})
+public class PubNoticia extends Auditoria {
+
+  /**
+   * ID de la noticia
+   */
+  @Id
+  @ColumnDefault("nextval('pub_noticia_id_pub_noticia_seq')")
+  @Column(name = "id_pub_noticia", nullable = false)
+  private Integer idPubNoticia;
+
+  /**
+   * Unidad académica que publica la noticia
+   */
+  @ManyToOne(fetch = FetchType.LAZY, optional = false)
+  @OnDelete(action = OnDeleteAction.RESTRICT)
+  @JoinColumn(name = "id_aca_unidad", nullable = false)
+  private AcaUnidad acaUnidad;
+
+  /**
+   * Título de la noticia
+   */
+  @Column(name = "titulo", nullable = false, length = 255)
+  private String titulo;
+
+  /**
+   * Resumen o descripción breve de la noticia
+   */
+  @Column(name = "resumen", nullable = false, columnDefinition = "TEXT")
+  private String resumen;
+
+  /**
+   * URI/ruta de la imagen de portada
+   */
+  @Column(name = "imagen_uri", length = 500)
+  private String imagenUri;
+
+  /**
+   * URL externa para más información (opcional)
+   */
+  @Column(name = "enlace_externo", length = 500)
+  private String enlaceExterno;
+
+  /**
+   * Fecha de publicación/vigencia de la noticia
+   */
+  @Column(name = "fecha_noticia", nullable = false)
+  private LocalDate fechaNoticia;
+
+  /**
+   * Marca si la noticia debe destacarse en el carrusel
+   */
+  @ColumnDefault("false")
+  @Column(name = "es_destacada")
+  private Boolean esDestacada;
+
+  /**
+   * Orden de prioridad para ordenamiento (mayor = más prioritario)
+   */
+  @ColumnDefault("0")
+  @Column(name = "orden_prioridad")
+  private Integer ordenPrioridad;
+
+  /**
+   * Estado de la noticia (ACTIVO, INACTIVO, ELIMINADO)
+   */
+  @Column(name = "estado_noticia", nullable = false, length = 35)
+  private String estadoNoticia;
+}

--- a/src/main/java/uap/edu/bo/cpeyfc/domain/pub_noticia/PubNoticiaRepository.java
+++ b/src/main/java/uap/edu/bo/cpeyfc/domain/pub_noticia/PubNoticiaRepository.java
@@ -1,0 +1,129 @@
+package uap.edu.bo.cpeyfc.domain.pub_noticia;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Repositorio: PubNoticiaRepository
+ * Descripción: Gestión de noticias institucionales para carrusel web
+ */
+public interface PubNoticiaRepository extends JpaRepository<PubNoticia, Integer> {
+
+  /**
+   * Vista: Listado completo de noticias activas para administración
+   * Noticias ordenadas por prioridad y fecha
+   *
+   * @return Lista de noticias activas con información completa
+   */
+  @Query(nativeQuery = true, value = "SELECT * FROM vista_noticias_activas")
+  List<Map<String, Object>> vistaNoticiasActivas();
+
+  /**
+   * Vista: Top 10 noticias optimizadas para carrusel web público
+   * Noticias destacadas primero, luego por prioridad y fecha
+   *
+   * @return Lista de las últimas 10 noticias para mostrar en carrusel
+   */
+  @Query(nativeQuery = true, value = "SELECT * FROM vista_noticias_carrusel")
+  List<Map<String, Object>> vistaNoticiasCarrusel();
+
+  /**
+   * Función: fn_registrar_noticia
+   * Registra una nueva noticia institucional
+   *
+   * @param p_id_aca_unidad     ID de la unidad que publica
+   * @param p_titulo            Título de la noticia
+   * @param p_resumen           Resumen o descripción breve
+   * @param p_imagen_uri        URI de la imagen de portada (opcional)
+   * @param p_enlace_externo    URL externa (opcional)
+   * @param p_fecha_noticia     Fecha de publicación
+   * @param p_es_destacada      Si debe destacarse en el carrusel
+   * @param p_orden_prioridad   Orden de prioridad (mayor = más prioritario)
+   * @param p_user_reg          ID del usuario que registra
+   * @return ID de la noticia creada
+   */
+  @Query(value = """
+        SELECT fn_registrar_noticia(
+            :p_id_aca_unidad,
+            :p_titulo,
+            :p_resumen,
+            :p_imagen_uri,
+            :p_enlace_externo,
+            :p_fecha_noticia,
+            :p_es_destacada,
+            :p_orden_prioridad,
+            :p_user_reg)
+        """, nativeQuery = true)
+  Integer registrarNoticia(Integer p_id_aca_unidad,
+                           String p_titulo,
+                           String p_resumen,
+                           String p_imagen_uri,
+                           String p_enlace_externo,
+                           LocalDate p_fecha_noticia,
+                           Boolean p_es_destacada,
+                           Integer p_orden_prioridad,
+                           Integer p_user_reg);
+
+  /**
+   * Función: fn_actualizar_noticia
+   * Actualiza los datos de una noticia existente
+   *
+   * @param p_id_pub_noticia    ID de la noticia a actualizar
+   * @param p_id_aca_unidad     ID de la unidad que publica
+   * @param p_titulo            Título de la noticia
+   * @param p_resumen           Resumen o descripción breve
+   * @param p_imagen_uri        URI de la imagen de portada (opcional)
+   * @param p_enlace_externo    URL externa (opcional)
+   * @param p_fecha_noticia     Fecha de publicación
+   * @param p_es_destacada      Si debe destacarse en el carrusel
+   * @param p_orden_prioridad   Orden de prioridad (mayor = más prioritario)
+   * @param p_user_mod          ID del usuario que modifica
+   * @return Mensaje de confirmación
+   */
+  @Query(value = """
+        SELECT fn_actualizar_noticia(
+            :p_id_pub_noticia,
+            :p_id_aca_unidad,
+            :p_titulo,
+            :p_resumen,
+            :p_imagen_uri,
+            :p_enlace_externo,
+            :p_fecha_noticia,
+            :p_es_destacada,
+            :p_orden_prioridad,
+            :p_user_mod)
+        """, nativeQuery = true)
+  String actualizarNoticia(Integer p_id_pub_noticia,
+                           Integer p_id_aca_unidad,
+                           String p_titulo,
+                           String p_resumen,
+                           String p_imagen_uri,
+                           String p_enlace_externo,
+                           LocalDate p_fecha_noticia,
+                           Boolean p_es_destacada,
+                           Integer p_orden_prioridad,
+                           Integer p_user_mod);
+
+  /**
+   * Función: fn_cambiar_estado_noticia
+   * Cambia el estado de una noticia (ACTIVO/INACTIVO/ELIMINADO)
+   *
+   * @param p_id_pub_noticia ID de la noticia
+   * @param p_nuevo_estado   Nuevo estado (ACTIVO, INACTIVO, ELIMINADO)
+   * @param p_user_mod       ID del usuario que modifica
+   * @return Mensaje de confirmación
+   */
+  @Query(value = """
+        SELECT fn_cambiar_estado_noticia(
+            :p_id_pub_noticia,
+            :p_nuevo_estado,
+            :p_user_mod)
+        """, nativeQuery = true)
+  String cambiarEstadoNoticia(Integer p_id_pub_noticia,
+                              String p_nuevo_estado,
+                              Integer p_user_mod);
+}


### PR DESCRIPTION
- Crear entidad AcaUnidad para catálogo de unidades académicas
- Crear repositorio AcaUnidadRepository con función de registro y vista de unidades activas
- Crear entidad PubNoticia para noticias institucionales con relación a AcaUnidad
- Crear repositorio PubNoticiaRepository con funciones de registro, actualización y cambio de estado
- Incluir vistas para carrusel web y administración de noticias