### PR TITLE
Fix: Centrado responsive del texto en InicioBanner

### DIFF
--- a/src/webapp/src/views/inicio/InicioBanner.vue
+++ b/src/webapp/src/views/inicio/InicioBanner.vue
@@ -52,9 +52,9 @@ const scrollHastaSobreNosotros = () => {
 }
 
 .inicio-banner__contenedor {
-  left: 40%;
+  left: 50%;
   text-align: center !important;
-  transform: translate(-30%, 30%);
+  transform: translate(-50%, 30%);
   position: absolute;
   z-index: 2;
   padding: 0 1rem;


### PR DESCRIPTION
- Cambia left de 40% a 50% para centrado horizontal correcto
- Ajusta transform de translate(-30%, 30%) a translate(-50%, 30%)
- Soluciona problema de layout roto con diferentes niveles de zoom (80%, 90%, 110%, 120%)
- Usa técnica estándar CSS para centrado absoluto que es independiente de resolución