### PR TITLE
Fix: Corregir mapeo de campos en carrusel de noticias

### DIFF
--- a/src/webapp/src/views/inicio/InicioNoticia.vue
+++ b/src/webapp/src/views/inicio/InicioNoticia.vue
@@ -8,7 +8,7 @@ const listaCarrusel = ref([])
 
 onMounted(async () => {
   try {
-    const response = await api.get('/noticia')
+    const response = await api.get('/publico/noticia/carrusel')
     listaNoticia.value = response.data
 
     // Dividir noticias en chunks de 2 para el carrusel

--- a/src/webapp/src/views/inicio/InicioNoticiaCard.vue
+++ b/src/webapp/src/views/inicio/InicioNoticiaCard.vue
@@ -7,24 +7,62 @@ const props = defineProps({
     required: true
   }
 })
+
+const openLink = () => {
+  if (props.noticia.enlace_externo) {
+    window.open(props.noticia.enlace_externo, '_blank')
+  }
+}
 </script>
 
 <template>
   <v-card class="noticia-card" elevation="4" rounded="lg" height="100%">
+    <v-img
+      v-if="noticia.imagen_uri"
+      :src="noticia.imagen_uri"
+      height="200"
+      cover
+      class="noticia-imagen"
+    >
+      <v-chip
+        v-if="noticia.es_destacada"
+        color="error"
+        size="small"
+        class="ma-2"
+      >
+        Destacada
+      </v-chip>
+    </v-img>
+
     <v-card-title class="text-h5 font-weight-bold">
       {{ noticia.titulo }}
     </v-card-title>
+
     <v-card-subtitle class="mt-2">
-      <v-icon icon="mdi-calendar" size="small"></v-icon>
-      {{ formatoFecha.completo(noticia.fechaPublicacion) }}
+      <div class="d-flex align-center gap-2">
+        <v-icon icon="mdi-calendar" size="small"></v-icon>
+        {{ formatoFecha.completo(noticia.fecha_noticia) }}
+      </div>
+      <div v-if="noticia.nombre_unidad" class="mt-1">
+        <v-icon icon="mdi-domain" size="small"></v-icon>
+        {{ noticia.nombre_unidad }}
+      </div>
     </v-card-subtitle>
+
     <v-card-text>
       <p class="text-body-2 text-truncate-3">
-        {{ noticia.contenido }}
+        {{ noticia.resumen }}
       </p>
     </v-card-text>
+
     <v-card-actions class="pa-4">
-      <v-btn color="primary" variant="text" append-icon="mdi-arrow-right">
+      <v-btn
+        v-if="noticia.enlace_externo"
+        color="primary"
+        variant="text"
+        append-icon="mdi-arrow-right"
+        @click="openLink"
+      >
         Leer más
       </v-btn>
     </v-card-actions>


### PR DESCRIPTION
- InicioNoticia.vue: Cambiar endpoint de '/noticia' a '/publico/noticia/carrusel'
- InicioNoticiaCard.vue: Ajustar campos para coincidir con vista_noticias_carrusel
  - Usar 'fecha_noticia' en lugar de 'fechaPublicacion'
  - Usar 'resumen' en lugar de 'contenido'
  - Agregar soporte para imagen_uri con badge de destacada
  - Mostrar nombre_unidad
  - Implementar funcionalidad de enlace_externo

Estos cambios aseguran que el carrusel use correctamente los datos devueltos por la API /api/publico/noticia/carrusel que consulta la vista vista_noticias_carrusel de la base de datos.