### PR TITLE
Set up news API database

### DIFF
--- a/src/webapp/src/layouts/LayoutCompleto.vue
+++ b/src/webapp/src/layouts/LayoutCompleto.vue
@@ -34,6 +34,12 @@ const menuItems = computed(() => [
     ruta: '/grupos',
     mostrar: hasPermission('VER_PROGRAMAS')
   },
+  {
+    titulo: 'Noticias',
+    icono: 'mdi-newspaper',
+    ruta: '/noticias',
+    mostrar: hasPermission('VER_PROGRAMAS')
+  },
   /*{
     titulo: 'Matrículas',
     icono: 'mdi-account-school',

--- a/src/webapp/src/router/index.js
+++ b/src/webapp/src/router/index.js
@@ -9,6 +9,7 @@ import rutasGrupos from '@/views/grupos/rutasGrupos.js';
 import rutasMatriculas from '@/views/matriculas/rutasMatriculas.js';
 import rutasPlanEstudio from '@/views/plan-estudio/rutasPlanEstudio.js';
 import rutasDocente from '@/views/docente/rutasDocente.js';
+import rutasNoticias from '@/views/noticias/rutasNoticias.js';
 
 const routes = [
   ...rutasPublicas,
@@ -20,6 +21,7 @@ const routes = [
   ...rutasMatriculas,
   ...rutasPlanEstudio,
   ...rutasDocente,
+  ...rutasNoticias,
 
   // Dashboard principal
   {

--- a/src/webapp/src/views/noticias/FormularioNoticia.vue
+++ b/src/webapp/src/views/noticias/FormularioNoticia.vue
@@ -1,0 +1,331 @@
+<script setup>
+import { ref, watch, computed, reactive, onMounted } from 'vue'
+import { useVuelidate } from '@vuelidate/core'
+import {
+  esRequerido,
+  longitudMinima,
+  longitudMaxima,
+  obtenerErroresCampo,
+  validarFormulario
+} from '@/helpers/validations'
+import { api } from '@/services/api'
+
+// Props
+const props = defineProps({
+  noticia: {
+    type: Object,
+    default: null
+  },
+  esEdicion: {
+    type: Boolean,
+    default: false
+  }
+})
+
+// Emits
+const emit = defineEmits(['guardar', 'cancelar'])
+
+// Estado del formulario
+const formularioNoticia = reactive({
+  id_aca_unidad: null,
+  titulo: '',
+  resumen: '',
+  imagen_uri: '',
+  enlace_externo: '',
+  fecha_noticia: new Date(),
+  es_destacada: false,
+  orden_prioridad: 0
+})
+
+// Estados
+const cargandoFormulario = ref(false)
+const unidades = ref([])
+
+// Validaciones
+const esquemaReglas = computed(() => ({
+  id_aca_unidad: { esRequerido },
+  titulo: {
+    esRequerido,
+    longitudMinima: longitudMinima(5),
+    longitudMaxima: longitudMaxima(255)
+  },
+  resumen: {
+    esRequerido,
+    longitudMinima: longitudMinima(20),
+    longitudMaxima: longitudMaxima(2000)
+  },
+  fecha_noticia: { esRequerido }
+}))
+
+// Instancia de Vuelidate
+const $v = useVuelidate(esquemaReglas, formularioNoticia)
+
+// Computed
+const textoBoton = computed(() =>
+  props.esEdicion ? 'Actualizar Noticia' : 'Crear Noticia'
+)
+
+// Cargar datos
+const cargarUnidades = async () => {
+  try {
+    const response = await api.get('/api/unidad/vista/unidades-activas')
+    unidades.value = response.data
+  } catch (error) {
+    console.error('Error al cargar unidades:', error)
+  }
+}
+
+// Preparar datos para envío
+const guardar = async () => {
+  const esValido = await validarFormulario($v.value)
+  if (!esValido) return
+
+  cargandoFormulario.value = true
+
+  try {
+    const datos = { ...formularioNoticia }
+    await emit('guardar', datos)
+    limpiarFormulario()
+  } catch (error) {
+    console.error('Error al guardar:', error)
+  } finally {
+    cargandoFormulario.value = false
+  }
+}
+
+const limpiarFormulario = () => {
+  Object.assign(formularioNoticia, {
+    id_aca_unidad: null,
+    titulo: '',
+    resumen: '',
+    imagen_uri: '',
+    enlace_externo: '',
+    fecha_noticia: new Date(),
+    es_destacada: false,
+    orden_prioridad: 0
+  })
+  $v.value.$reset()
+}
+
+const cancelar = () => {
+  limpiarFormulario()
+  emit('cancelar')
+}
+
+// Cargar datos al editar
+const cargarDatosNoticia = (noticia) => {
+  if (!noticia) return
+
+  formularioNoticia.id_aca_unidad = noticia.id_aca_unidad
+  formularioNoticia.titulo = noticia.titulo
+  formularioNoticia.resumen = noticia.resumen
+  formularioNoticia.imagen_uri = noticia.imagen_uri || ''
+  formularioNoticia.enlace_externo = noticia.enlace_externo || ''
+  formularioNoticia.fecha_noticia = noticia.fecha_noticia ? new Date(noticia.fecha_noticia) : new Date()
+  formularioNoticia.es_destacada = noticia.es_destacada || false
+  formularioNoticia.orden_prioridad = noticia.orden_prioridad || 0
+}
+
+// Watchers
+watch(() => props.noticia, (noticia) => {
+  if (noticia && props.esEdicion) {
+    cargarDatosNoticia(noticia)
+  }
+}, { immediate: true })
+
+onMounted(() => {
+  cargarUnidades()
+})
+</script>
+
+<template>
+  <div class="formulario-noticia">
+    <v-card-text class="pa-6">
+      <v-form>
+        <v-row>
+          <!-- Unidad Académica -->
+          <v-col cols="12">
+            <v-select
+              v-model="formularioNoticia.id_aca_unidad"
+              :items="unidades"
+              :error-messages="obtenerErroresCampo($v.id_aca_unidad)"
+              item-title="nombre_unidad"
+              item-value="id_aca_unidad"
+              label="Unidad que publica *"
+              variant="outlined"
+              prepend-inner-icon="mdi-domain"
+              :disabled="cargandoFormulario"
+            >
+              <template #item="{ props, item }">
+                <v-list-item v-bind="props">
+                  <template #title>{{ item.raw.nombre_unidad }}</template>
+                  <template #subtitle v-if="item.raw.descripcion">
+                    {{ item.raw.descripcion }}
+                  </template>
+                </v-list-item>
+              </template>
+            </v-select>
+          </v-col>
+
+          <!-- Título -->
+          <v-col cols="12">
+            <v-text-field
+              v-model="formularioNoticia.titulo"
+              :error-messages="obtenerErroresCampo($v.titulo)"
+              label="Título de la noticia *"
+              variant="outlined"
+              prepend-inner-icon="mdi-format-title"
+              :disabled="cargandoFormulario"
+              counter="255"
+              hint="Mínimo 5 caracteres"
+              persistent-hint
+            ></v-text-field>
+          </v-col>
+
+          <!-- Resumen/Descripción -->
+          <v-col cols="12">
+            <v-textarea
+              v-model="formularioNoticia.resumen"
+              :error-messages="obtenerErroresCampo($v.resumen)"
+              label="Descripción de la noticia *"
+              variant="outlined"
+              prepend-inner-icon="mdi-text"
+              :disabled="cargandoFormulario"
+              counter="2000"
+              rows="4"
+              hint="Mínimo 20 caracteres"
+              persistent-hint
+            ></v-textarea>
+          </v-col>
+
+          <!-- Fecha de Noticia -->
+          <v-col cols="12" md="6">
+            <v-date-input
+              v-model="formularioNoticia.fecha_noticia"
+              :error-messages="obtenerErroresCampo($v.fecha_noticia)"
+              label="Fecha de la noticia *"
+              variant="outlined"
+              prepend-inner-icon="mdi-calendar"
+              :disabled="cargandoFormulario"
+            ></v-date-input>
+          </v-col>
+
+          <!-- Orden Prioridad -->
+          <v-col cols="12" md="6">
+            <v-text-field
+              v-model.number="formularioNoticia.orden_prioridad"
+              label="Orden de prioridad"
+              variant="outlined"
+              prepend-inner-icon="mdi-sort-numeric-variant"
+              type="number"
+              min="0"
+              :disabled="cargandoFormulario"
+              hint="Mayor número = más prioritario (0 por defecto)"
+              persistent-hint
+            ></v-text-field>
+          </v-col>
+
+          <!-- Sección opcionales -->
+          <v-col cols="12">
+            <v-divider class="my-2"></v-divider>
+            <div class="text-subtitle-2 text-medium-emphasis mb-4">Información Adicional (Opcional)</div>
+          </v-col>
+
+          <!-- Imagen URI -->
+          <v-col cols="12" md="6">
+            <v-text-field
+              v-model="formularioNoticia.imagen_uri"
+              label="URL de la imagen"
+              variant="outlined"
+              prepend-inner-icon="mdi-image"
+              :disabled="cargandoFormulario"
+              hint="URL o ruta de la imagen"
+              persistent-hint
+            ></v-text-field>
+          </v-col>
+
+          <!-- Enlace Externo -->
+          <v-col cols="12" md="6">
+            <v-text-field
+              v-model="formularioNoticia.enlace_externo"
+              label="Enlace externo"
+              variant="outlined"
+              prepend-inner-icon="mdi-link"
+              :disabled="cargandoFormulario"
+              hint="URL para más información"
+              persistent-hint
+            ></v-text-field>
+          </v-col>
+
+          <!-- Destacada -->
+          <v-col cols="12">
+            <v-switch
+              v-model="formularioNoticia.es_destacada"
+              label="Marcar como noticia destacada"
+              color="warning"
+              inset
+              :disabled="cargandoFormulario"
+              hint="Las noticias destacadas aparecen primero en el carrusel"
+              persistent-hint
+            >
+              <template #prepend>
+                <v-icon>mdi-star</v-icon>
+              </template>
+            </v-switch>
+          </v-col>
+        </v-row>
+      </v-form>
+    </v-card-text>
+
+    <!-- Acciones -->
+    <v-card-actions class="pa-6 pt-0">
+      <v-spacer></v-spacer>
+
+      <v-btn
+        variant="text"
+        @click="cancelar"
+        :disabled="cargandoFormulario"
+      >
+        Cancelar
+      </v-btn>
+
+      <v-btn
+        color="primary"
+        variant="elevated"
+        :loading="cargandoFormulario"
+        @click="guardar"
+      >
+        <v-icon start>mdi-content-save</v-icon>
+        {{ textoBoton }}
+      </v-btn>
+    </v-card-actions>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.formulario-noticia {
+  .v-card-text {
+    max-height: 70vh;
+    overflow-y: auto;
+  }
+}
+
+// Responsive
+@media (max-width: 600px) {
+  .formulario-noticia {
+    .v-card-text {
+      padding: 16px !important;
+    }
+
+    .v-card-actions {
+      padding: 16px !important;
+      flex-direction: column;
+      gap: 8px;
+
+      .v-btn {
+        width: 100%;
+      }
+    }
+  }
+}
+</style>

--- a/src/webapp/src/views/noticias/ListaNoticias.vue
+++ b/src/webapp/src/views/noticias/ListaNoticias.vue
@@ -1,0 +1,341 @@
+<script setup>
+import { onMounted, ref, computed } from 'vue'
+import { api } from '@/services/api'
+import FormularioNoticia from '@/views/noticias/FormularioNoticia.vue'
+import formatoFecha from '@/helpers/formatos.js'
+
+const noticias = ref([])
+const cargando = ref(false)
+const busqueda = ref('')
+
+// Estados de dialog
+const dialogFormulario = ref(false)
+const noticiaSeleccionada = ref(null)
+const esEdicion = computed(() => !!noticiaSeleccionada.value)
+
+// Headers de la tabla
+const headers = [
+  { title: 'Título', key: 'titulo', sortable: true, width: '30%' },
+  { title: 'Unidad', key: 'nombre_unidad', sortable: true, width: '20%' },
+  { title: 'Fecha', key: 'fecha_noticia', sortable: true, width: '12%' },
+  { title: 'Destacada', key: 'es_destacada', sortable: true, width: '10%' },
+  { title: 'Prioridad', key: 'orden_prioridad', sortable: true, width: '10%' },
+  { title: 'Estado', key: 'estado_noticia', sortable: true, width: '10%' },
+  { title: 'Acciones', key: 'acciones', sortable: false, width: '8%' }
+]
+
+// Computed para formatear datos
+const noticiasFormateadas = computed(() => {
+  return noticias.value.map(noticia => ({
+    ...noticia,
+    fecha_formateada: noticia.fecha_noticia ? formatoFecha.ddMMaaaa(noticia.fecha_noticia) : 'Sin fecha'
+  }))
+})
+
+const obtenerNoticias = async () => {
+  cargando.value = true
+  try {
+    const response = await api.get('/api/noticia/vista/noticias-activas')
+    noticias.value = response.data
+  } catch (error) {
+    console.error('Error al obtener noticias:', error)
+  } finally {
+    cargando.value = false
+  }
+}
+
+const obtenerColorEstado = (estado) => {
+  const colores = {
+    'ACTIVO': 'success',
+    'INACTIVO': 'warning',
+    'ELIMINADO': 'error'
+  }
+  return colores[estado] || 'grey'
+}
+
+// Funciones de dialog
+const abrirDialogRegistrar = () => {
+  noticiaSeleccionada.value = null
+  dialogFormulario.value = true
+}
+
+const abrirDialogEditar = (noticia) => {
+  noticiaSeleccionada.value = noticia
+  dialogFormulario.value = true
+}
+
+const cerrarDialog = () => {
+  dialogFormulario.value = false
+  noticiaSeleccionada.value = null
+}
+
+const guardarNoticia = async (datos) => {
+  try {
+    cargando.value = true
+
+    if (esEdicion.value) {
+      await api.put(`/api/noticia/${noticiaSeleccionada.value.id_pub_noticia}`, datos)
+    } else {
+      await api.post('/api/noticia', datos)
+    }
+
+    await obtenerNoticias()
+    cerrarDialog()
+    console.log('Noticia guardada exitosamente')
+  } catch (error) {
+    console.error('Error al guardar noticia:', error)
+    alert('Error al guardar la noticia: ' + (error.response?.data || error.message))
+  } finally {
+    cargando.value = false
+  }
+}
+
+const cambiarEstadoNoticia = async (noticia, nuevoEstado) => {
+  const confirmacion = nuevoEstado === 'ELIMINADO'
+    ? '¿Está seguro de eliminar esta noticia?'
+    : `¿Cambiar el estado a ${nuevoEstado}?`
+
+  if (!confirm(confirmacion)) return
+
+  try {
+    await api.patch(`/api/noticia/${noticia.id_pub_noticia}/estado`, {
+      estado: nuevoEstado
+    })
+
+    await obtenerNoticias()
+    console.log('Estado actualizado exitosamente')
+  } catch (error) {
+    console.error('Error al cambiar estado:', error)
+    alert('Error al cambiar el estado: ' + (error.response?.data || error.message))
+  }
+}
+
+onMounted(() => {
+  obtenerNoticias()
+})
+</script>
+
+<template>
+  <div class="pa-4">
+    <!-- Tabla de noticias -->
+    <v-card class="rounded-lg">
+      <v-data-table
+        :headers="headers"
+        :items="noticiasFormateadas"
+        :loading="cargando"
+        :search="busqueda"
+        loading-text="Cargando noticias..."
+        no-data-text="No hay noticias registradas"
+        class="rounded-lg"
+        density="comfortable"
+      >
+        <template #top>
+          <v-toolbar flat class="rounded-t-lg pa-4">
+            <v-toolbar-title class="text-h6 font-weight-bold d-flex align-center">
+              <v-icon class="mr-2" color="primary">mdi-newspaper</v-icon>
+              Administración de Noticias
+            </v-toolbar-title>
+            <v-spacer></v-spacer>
+
+            <div class="d-flex align-center ga-3 flex-wrap">
+              <v-text-field
+                v-model="busqueda"
+                append-inner-icon="mdi-magnify"
+                label="Buscar noticias..."
+                single-line
+                hide-details
+                variant="outlined"
+                density="compact"
+                class="search-field"
+              ></v-text-field>
+
+              <v-btn
+                color="primary"
+                variant="elevated"
+                class="btn-nuevo"
+                @click="abrirDialogRegistrar"
+              >
+                <v-icon start>mdi-plus</v-icon>
+                Nueva Noticia
+              </v-btn>
+            </div>
+          </v-toolbar>
+        </template>
+
+        <template #item.titulo="{ item }">
+          <div>
+            <div class="text-body-1 font-weight-medium">
+              {{ item.titulo }}
+            </div>
+            <div class="text-caption text-medium-emphasis" v-if="item.resumen">
+              {{ item.resumen.substring(0, 80) }}{{ item.resumen.length > 80 ? '...' : '' }}
+            </div>
+          </div>
+        </template>
+
+        <template #item.fecha_noticia="{ item }">
+          <div class="d-flex align-center">
+            <v-icon size="small" class="mr-1">mdi-calendar</v-icon>
+            <span class="text-body-2">{{ item.fecha_formateada }}</span>
+          </div>
+        </template>
+
+        <template #item.es_destacada="{ item }">
+          <v-icon
+            :color="item.es_destacada ? 'warning' : 'grey'"
+            size="small"
+          >
+            {{ item.es_destacada ? 'mdi-star' : 'mdi-star-outline' }}
+          </v-icon>
+        </template>
+
+        <template #item.orden_prioridad="{ item }">
+          <v-chip
+            v-if="item.orden_prioridad > 0"
+            :color="item.orden_prioridad >= 10 ? 'error' : item.orden_prioridad >= 5 ? 'warning' : 'info'"
+            size="small"
+            variant="flat"
+          >
+            {{ item.orden_prioridad }}
+          </v-chip>
+          <span v-else class="text-caption text-medium-emphasis">{{ item.orden_prioridad }}</span>
+        </template>
+
+        <template #item.estado_noticia="{ item }">
+          <v-chip
+            :color="obtenerColorEstado(item.estado_noticia)"
+            size="small"
+            variant="flat"
+          >
+            {{ item.estado_noticia }}
+          </v-chip>
+        </template>
+
+        <template #item.acciones="{ item }">
+          <div class="d-flex ga-1">
+            <v-btn
+              icon="mdi-pencil"
+              size="small"
+              color="primary"
+              variant="elevated"
+              @click="abrirDialogEditar(item)"
+            >
+              <v-icon>mdi-pencil</v-icon>
+              <v-tooltip activator="parent" location="top">Editar</v-tooltip>
+            </v-btn>
+
+            <v-menu>
+              <template #activator="{ props }">
+                <v-btn
+                  color="primary"
+                  icon="mdi-dots-vertical"
+                  size="small"
+                  variant="elevated"
+                  v-bind="props"
+                >
+                  <v-icon>mdi-dots-vertical</v-icon>
+                </v-btn>
+              </template>
+
+              <v-list density="compact">
+                <v-list-item
+                  @click="cambiarEstadoNoticia(item, 'ACTIVO')"
+                  :disabled="item.estado_noticia === 'ACTIVO'"
+                >
+                  <template #prepend>
+                    <v-icon color="success">mdi-check-circle</v-icon>
+                  </template>
+                  <v-list-item-title>Activar</v-list-item-title>
+                </v-list-item>
+
+                <v-list-item
+                  @click="cambiarEstadoNoticia(item, 'INACTIVO')"
+                  :disabled="item.estado_noticia === 'INACTIVO'"
+                >
+                  <template #prepend>
+                    <v-icon color="warning">mdi-pause-circle</v-icon>
+                  </template>
+                  <v-list-item-title>Desactivar</v-list-item-title>
+                </v-list-item>
+
+                <v-divider></v-divider>
+
+                <v-list-item @click="cambiarEstadoNoticia(item, 'ELIMINADO')">
+                  <template #prepend>
+                    <v-icon color="error">mdi-delete</v-icon>
+                  </template>
+                  <v-list-item-title>Eliminar</v-list-item-title>
+                </v-list-item>
+              </v-list>
+            </v-menu>
+          </div>
+        </template>
+      </v-data-table>
+    </v-card>
+
+    <!-- Dialog para formulario -->
+    <v-dialog
+      v-model="dialogFormulario"
+      max-width="800px"
+      persistent
+      class="ma-2"
+    >
+      <v-card class="rounded-lg">
+        <v-card-title class="bg-primary text-white d-flex align-center pa-4">
+          <v-icon start>{{ esEdicion ? 'mdi-newspaper-variant' : 'mdi-newspaper-plus' }}</v-icon>
+          {{ esEdicion ? 'Editar Noticia' : 'Nueva Noticia' }}
+        </v-card-title>
+
+        <FormularioNoticia
+          :noticia="noticiaSeleccionada"
+          :es-edicion="esEdicion"
+          @cancelar="cerrarDialog"
+          @guardar="guardarNoticia"
+        />
+      </v-card>
+    </v-dialog>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+.search-field {
+  min-width: 280px;
+  max-width: 350px;
+}
+
+.btn-nuevo {
+  min-width: 160px;
+  flex-shrink: 0;
+}
+
+@media (max-width: 960px) {
+  .v-toolbar {
+    .d-flex.align-center.ga-3 {
+      flex-direction: column;
+      align-items: stretch !important;
+      gap: 16px !important;
+      width: 100%;
+    }
+
+    .v-toolbar-title {
+      text-align: center;
+      margin-bottom: 8px;
+    }
+
+    .search-field {
+      min-width: 100%;
+      max-width: 100%;
+    }
+
+    .btn-nuevo {
+      min-width: 100%;
+    }
+  }
+}
+
+@media (max-width: 600px) {
+  .v-toolbar {
+    padding: 16px !important;
+  }
+}
+</style>

--- a/src/webapp/src/views/noticias/rutasNoticias.js
+++ b/src/webapp/src/views/noticias/rutasNoticias.js
@@ -1,0 +1,11 @@
+export default [
+  {
+    path: '/noticias',
+    name: 'ListaNoticias',
+    component: () => import('./ListaNoticias.vue'),
+    meta: {
+      requiresAuth: true,
+      /*requiredPermissions: ['VER_NOTICIAS']*/
+    }
+  }
+]


### PR DESCRIPTION
- Crear FormularioNoticia.vue: formulario simple con campos básicos
  - Título, resumen, unidad que publica, fecha de noticia
  - Campos opcionales: imagen_uri, enlace_externo, es_destacada, orden_prioridad
  - Validaciones con Vuelidate

- Crear ListaNoticias.vue: tabla de administración de noticias
  - Listado con búsqueda y filtros
  - Acciones: crear, editar, cambiar estado (activar/desactivar/eliminar)
  - Indicadores visuales para destacadas y prioridad

- Agregar rutasNoticias.js y configurar en router
- Agregar menú "Noticias" en LayoutCompleto.vue

Basado en endpoints de PubNoticiaApi y migración de base de datos.