### PR TITLE
Feat: Agregar subida de imágenes y mejorar UI de prioridad

### DIFF
--- a/src/main/java/uap/edu/bo/cpeyfc/FileUploadApi.java
+++ b/src/main/java/uap/edu/bo/cpeyfc/FileUploadApi.java
@@ -1,0 +1,126 @@
+package uap.edu.bo.cpeyfc;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import uap.edu.bo.cpeyfc.util.FileStorageService;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * API: FileUploadApi
+ * Descripción: Endpoints REST para subir archivos (imágenes, documentos, etc.)
+ */
+@RestController
+@RequiredArgsConstructor
+@Slf4j
+public class FileUploadApi {
+
+  private final FileStorageService fileStorageService;
+
+  /**
+   * POST /api/archivo/noticia/imagen
+   * Sube una imagen para una noticia
+   *
+   * Request: multipart/form-data con campo 'file'
+   *
+   * Response:
+   * {
+   *   "success": true,
+   *   "message": "Imagen subida exitosamente",
+   *   "url": "/noticias/noticia_20250107_123456_abc123.jpg"
+   * }
+   *
+   * @param file Archivo de imagen a subir
+   * @return Respuesta con la URL del archivo guardado
+   */
+  @PostMapping("/api/archivo/noticia/imagen")
+  public ResponseEntity<Map<String, Object>> subirImagenNoticia(
+      @RequestParam("file") MultipartFile file) {
+
+    try {
+      log.info("Recibiendo archivo: {} - Tamaño: {} bytes - Tipo: {}",
+          file.getOriginalFilename(), file.getSize(), file.getContentType());
+
+      String rutaRelativa = fileStorageService.guardarImagenNoticia(file);
+
+      Map<String, Object> response = new HashMap<>();
+      response.put("success", true);
+      response.put("message", "Imagen subida exitosamente");
+      response.put("url", rutaRelativa);
+
+      log.info("Imagen guardada exitosamente en: {}", rutaRelativa);
+
+      return ResponseEntity.ok(response);
+
+    } catch (IllegalArgumentException e) {
+      log.warn("Validación de archivo fallida: {}", e.getMessage());
+
+      Map<String, Object> errorResponse = new HashMap<>();
+      errorResponse.put("success", false);
+      errorResponse.put("message", e.getMessage());
+
+      return ResponseEntity.badRequest().body(errorResponse);
+
+    } catch (Exception e) {
+      log.error("Error al subir archivo", e);
+
+      Map<String, Object> errorResponse = new HashMap<>();
+      errorResponse.put("success", false);
+      errorResponse.put("message", "Error al guardar el archivo: " + e.getMessage());
+
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+    }
+  }
+
+  /**
+   * DELETE /api/archivo/noticia/imagen
+   * Elimina una imagen de noticia del servidor
+   *
+   * Request body:
+   * {
+   *   "url": "/noticias/imagen.jpg"
+   * }
+   *
+   * @param datos Datos con la URL de la imagen a eliminar
+   * @return Respuesta con el resultado de la eliminación
+   */
+  @DeleteMapping("/api/archivo/noticia/imagen")
+  public ResponseEntity<Map<String, Object>> eliminarImagenNoticia(
+      @RequestBody Map<String, String> datos) {
+
+    try {
+      String url = datos.get("url");
+
+      if (url == null || url.isEmpty()) {
+        Map<String, Object> errorResponse = new HashMap<>();
+        errorResponse.put("success", false);
+        errorResponse.put("message", "La URL de la imagen es requerida");
+        return ResponseEntity.badRequest().body(errorResponse);
+      }
+
+      boolean eliminado = fileStorageService.eliminarImagenNoticia(url);
+
+      Map<String, Object> response = new HashMap<>();
+      response.put("success", eliminado);
+      response.put("message", eliminado
+          ? "Imagen eliminada exitosamente"
+          : "La imagen no existe o ya fue eliminada");
+
+      return ResponseEntity.ok(response);
+
+    } catch (Exception e) {
+      log.error("Error al eliminar archivo", e);
+
+      Map<String, Object> errorResponse = new HashMap<>();
+      errorResponse.put("success", false);
+      errorResponse.put("message", "Error al eliminar el archivo: " + e.getMessage());
+
+      return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+    }
+  }
+}

--- a/src/main/java/uap/edu/bo/cpeyfc/util/FileStorageService.java
+++ b/src/main/java/uap/edu/bo/cpeyfc/util/FileStorageService.java
@@ -1,0 +1,176 @@
+package uap.edu.bo.cpeyfc.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardCopyOption;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Servicio para manejo de archivos subidos
+ * Guarda archivos en el sistema de archivos local
+ */
+@Service
+@Slf4j
+public class FileStorageService {
+
+  // Directorio base donde se almacenan todos los archivos
+  private static final String BASE_UPLOAD_DIR = "src/main/resources/static";
+
+  // Directorio específico para imágenes de noticias
+  private static final String NEWS_IMAGES_DIR = "noticias";
+
+  // Extensiones de imagen permitidas
+  private static final List<String> ALLOWED_IMAGE_EXTENSIONS = Arrays.asList(
+      "jpg", "jpeg", "png", "gif", "webp", "svg", "bmp"
+  );
+
+  // Tamaño máximo de archivo: 5MB
+  private static final long MAX_FILE_SIZE = 5 * 1024 * 1024;
+
+  /**
+   * Guarda una imagen de noticia en el servidor
+   *
+   * @param file Archivo subido
+   * @return Ruta relativa del archivo guardado (ej: /noticias/imagen_20250107_123456_abc123.jpg)
+   * @throws IOException Si ocurre un error al guardar
+   * @throws IllegalArgumentException Si el archivo no es válido
+   */
+  public String guardarImagenNoticia(MultipartFile file) throws IOException {
+    // Validaciones
+    validarArchivo(file);
+
+    // Crear directorio si no existe
+    Path uploadPath = crearDirectorioSiNoExiste(NEWS_IMAGES_DIR);
+
+    // Generar nombre único para el archivo
+    String nombreUnico = generarNombreUnico(file.getOriginalFilename());
+
+    // Guardar archivo
+    Path destinoArchivo = uploadPath.resolve(nombreUnico);
+    Files.copy(file.getInputStream(), destinoArchivo, StandardCopyOption.REPLACE_EXISTING);
+
+    log.info("Archivo guardado exitosamente: {}", destinoArchivo);
+
+    // Retornar ruta relativa (accesible desde /noticias/nombre.jpg)
+    return "/" + NEWS_IMAGES_DIR + "/" + nombreUnico;
+  }
+
+  /**
+   * Elimina una imagen de noticia del servidor
+   *
+   * @param rutaRelativa Ruta relativa del archivo (ej: /noticias/imagen.jpg)
+   * @return true si se eliminó, false si no existía
+   */
+  public boolean eliminarImagenNoticia(String rutaRelativa) {
+    try {
+      if (rutaRelativa == null || rutaRelativa.isEmpty()) {
+        return false;
+      }
+
+      // Extraer nombre del archivo de la ruta relativa
+      String nombreArchivo = rutaRelativa.substring(rutaRelativa.lastIndexOf("/") + 1);
+      Path archivoPath = Paths.get(BASE_UPLOAD_DIR, NEWS_IMAGES_DIR, nombreArchivo);
+
+      boolean eliminado = Files.deleteIfExists(archivoPath);
+
+      if (eliminado) {
+        log.info("Archivo eliminado exitosamente: {}", archivoPath);
+      } else {
+        log.warn("Archivo no encontrado para eliminar: {}", archivoPath);
+      }
+
+      return eliminado;
+
+    } catch (IOException e) {
+      log.error("Error al eliminar archivo: {}", rutaRelativa, e);
+      return false;
+    }
+  }
+
+  /**
+   * Valida que el archivo sea una imagen válida
+   */
+  private void validarArchivo(MultipartFile file) {
+    // Verificar que no esté vacío
+    if (file == null || file.isEmpty()) {
+      throw new IllegalArgumentException("El archivo está vacío");
+    }
+
+    // Verificar tamaño
+    if (file.getSize() > MAX_FILE_SIZE) {
+      throw new IllegalArgumentException(
+          String.format("El archivo excede el tamaño máximo permitido de %d MB",
+              MAX_FILE_SIZE / (1024 * 1024))
+      );
+    }
+
+    // Verificar extensión
+    String nombreOriginal = file.getOriginalFilename();
+    if (nombreOriginal == null || !tieneExtensionValida(nombreOriginal)) {
+      throw new IllegalArgumentException(
+          "Formato de archivo no permitido. Permitidos: " + String.join(", ", ALLOWED_IMAGE_EXTENSIONS)
+      );
+    }
+
+    // Verificar content type
+    String contentType = file.getContentType();
+    if (contentType == null || !contentType.startsWith("image/")) {
+      throw new IllegalArgumentException("El archivo debe ser una imagen");
+    }
+  }
+
+  /**
+   * Verifica si el archivo tiene una extensión válida
+   */
+  private boolean tieneExtensionValida(String nombreArchivo) {
+    String extension = obtenerExtension(nombreArchivo).toLowerCase();
+    return ALLOWED_IMAGE_EXTENSIONS.contains(extension);
+  }
+
+  /**
+   * Obtiene la extensión del archivo
+   */
+  private String obtenerExtension(String nombreArchivo) {
+    int ultimoPunto = nombreArchivo.lastIndexOf('.');
+    if (ultimoPunto == -1) {
+      return "";
+    }
+    return nombreArchivo.substring(ultimoPunto + 1);
+  }
+
+  /**
+   * Genera un nombre único para el archivo usando timestamp y UUID
+   */
+  private String generarNombreUnico(String nombreOriginal) {
+    String extension = obtenerExtension(nombreOriginal);
+    String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMdd_HHmmss"));
+    String uuid = UUID.randomUUID().toString().substring(0, 8);
+
+    return String.format("noticia_%s_%s.%s", timestamp, uuid, extension);
+  }
+
+  /**
+   * Crea el directorio de destino si no existe
+   */
+  private Path crearDirectorioSiNoExiste(String subdirectorio) throws IOException {
+    Path uploadPath = Paths.get(BASE_UPLOAD_DIR, subdirectorio);
+
+    if (!Files.exists(uploadPath)) {
+      Files.createDirectories(uploadPath);
+      log.info("Directorio creado: {}", uploadPath);
+    }
+
+    return uploadPath;
+  }
+}

--- a/src/webapp/src/views/noticias/FormularioNoticia.vue
+++ b/src/webapp/src/views/noticias/FormularioNoticia.vue
@@ -39,7 +39,17 @@ const formularioNoticia = reactive({
 
 // Estados
 const cargandoFormulario = ref(false)
+const subiendoImagen = ref(false)
 const unidades = ref([])
+const archivoImagen = ref(null)
+const previewImagen = ref(null)
+
+// Opciones de prioridad
+const opcionesPrioridad = [
+  { titulo: 'Baja', valor: 0, descripcion: 'Noticia normal', color: 'grey', icono: 'mdi-arrow-down' },
+  { titulo: 'Media', valor: 5, descripcion: 'Noticia importante', color: 'warning', icono: 'mdi-minus' },
+  { titulo: 'Alta', valor: 10, descripcion: 'Noticia prioritaria', color: 'error', icono: 'mdi-arrow-up' }
+]
 
 // Validaciones
 const esquemaReglas = computed(() => ({
@@ -65,6 +75,10 @@ const textoBoton = computed(() =>
   props.esEdicion ? 'Actualizar Noticia' : 'Crear Noticia'
 )
 
+const prioridadSeleccionada = computed(() => {
+  return opcionesPrioridad.find(p => p.valor === formularioNoticia.orden_prioridad) || opcionesPrioridad[0]
+})
+
 // Cargar datos
 const cargarUnidades = async () => {
   try {
@@ -72,6 +86,62 @@ const cargarUnidades = async () => {
     unidades.value = response.data
   } catch (error) {
     console.error('Error al cargar unidades:', error)
+  }
+}
+
+// Manejo de imágenes
+const onArchivoSeleccionado = (files) => {
+  if (!files || files.length === 0) {
+    archivoImagen.value = null
+    previewImagen.value = null
+    return
+  }
+
+  const file = files[0]
+  archivoImagen.value = file
+
+  // Generar preview
+  const reader = new FileReader()
+  reader.onload = (e) => {
+    previewImagen.value = e.target.result
+  }
+  reader.readAsDataURL(file)
+}
+
+const eliminarImagen = () => {
+  archivoImagen.value = null
+  previewImagen.value = null
+  formularioNoticia.imagen_uri = ''
+}
+
+const subirImagen = async () => {
+  if (!archivoImagen.value) {
+    return null
+  }
+
+  subiendoImagen.value = true
+
+  try {
+    const formData = new FormData()
+    formData.append('file', archivoImagen.value)
+
+    const response = await api.post('/api/archivo/noticia/imagen', formData, {
+      headers: {
+        'Content-Type': 'multipart/form-data'
+      }
+    })
+
+    if (response.data.success) {
+      return response.data.url
+    } else {
+      throw new Error(response.data.message || 'Error al subir imagen')
+    }
+  } catch (error) {
+    console.error('Error al subir imagen:', error)
+    alert('Error al subir la imagen: ' + (error.response?.data?.message || error.message))
+    throw error
+  } finally {
+    subiendoImagen.value = false
   }
 }
 
@@ -83,6 +153,14 @@ const guardar = async () => {
   cargandoFormulario.value = true
 
   try {
+    // Si hay una imagen nueva, subirla primero
+    if (archivoImagen.value) {
+      const urlImagen = await subirImagen()
+      if (urlImagen) {
+        formularioNoticia.imagen_uri = urlImagen
+      }
+    }
+
     const datos = { ...formularioNoticia }
     await emit('guardar', datos)
     limpiarFormulario()
@@ -104,6 +182,8 @@ const limpiarFormulario = () => {
     es_destacada: false,
     orden_prioridad: 0
   })
+  archivoImagen.value = null
+  previewImagen.value = null
   $v.value.$reset()
 }
 
@@ -124,6 +204,11 @@ const cargarDatosNoticia = (noticia) => {
   formularioNoticia.fecha_noticia = noticia.fecha_noticia ? new Date(noticia.fecha_noticia) : new Date()
   formularioNoticia.es_destacada = noticia.es_destacada || false
   formularioNoticia.orden_prioridad = noticia.orden_prioridad || 0
+
+  // Si hay imagen existente, mostrar preview
+  if (noticia.imagen_uri) {
+    previewImagen.value = noticia.imagen_uri
+  }
 }
 
 // Watchers
@@ -210,19 +295,119 @@ onMounted(() => {
             ></v-date-input>
           </v-col>
 
-          <!-- Orden Prioridad -->
+          <!-- Prioridad Visual -->
           <v-col cols="12" md="6">
-            <v-text-field
-              v-model.number="formularioNoticia.orden_prioridad"
-              label="Orden de prioridad"
+            <v-select
+              v-model="formularioNoticia.orden_prioridad"
+              :items="opcionesPrioridad"
+              item-title="titulo"
+              item-value="valor"
+              label="Prioridad en el carrusel"
               variant="outlined"
-              prepend-inner-icon="mdi-sort-numeric-variant"
-              type="number"
-              min="0"
+              prepend-inner-icon="mdi-priority-high"
               :disabled="cargandoFormulario"
-              hint="Mayor número = más prioritario (0 por defecto)"
+              hint="Define qué tan arriba aparecerá en el carrusel"
               persistent-hint
-            ></v-text-field>
+            >
+              <template #item="{ props, item }">
+                <v-list-item v-bind="props">
+                  <template #prepend>
+                    <v-icon :color="item.raw.color">{{ item.raw.icono }}</v-icon>
+                  </template>
+                  <template #title>
+                    <span :class="`text-${item.raw.color}`">{{ item.raw.titulo }}</span>
+                  </template>
+                  <template #subtitle>
+                    {{ item.raw.descripcion }}
+                  </template>
+                </v-list-item>
+              </template>
+
+              <template #selection="{ item }">
+                <div class="d-flex align-center">
+                  <v-icon :color="item.raw.color" size="small" class="mr-2">
+                    {{ item.raw.icono }}
+                  </v-icon>
+                  <span>{{ item.raw.titulo }} - {{ item.raw.descripcion }}</span>
+                </div>
+              </template>
+            </v-select>
+          </v-col>
+
+          <!-- Sección de imagen -->
+          <v-col cols="12">
+            <v-divider class="my-2"></v-divider>
+            <div class="text-subtitle-2 text-medium-emphasis mb-4">
+              <v-icon size="small" class="mr-1">mdi-image</v-icon>
+              Imagen de la Noticia
+            </div>
+          </v-col>
+
+          <!-- Subida de Imagen -->
+          <v-col cols="12" md="6">
+            <v-file-input
+              v-model="archivoImagen"
+              label="Seleccionar imagen"
+              variant="outlined"
+              prepend-icon=""
+              prepend-inner-icon="mdi-image-plus"
+              accept="image/png, image/jpeg, image/jpg, image/webp, image/gif"
+              :disabled="cargandoFormulario"
+              :loading="subiendoImagen"
+              show-size
+              hint="Formatos: PNG, JPG, WEBP, GIF. Máx: 5MB"
+              persistent-hint
+              @update:model-value="onArchivoSeleccionado"
+            >
+              <template #selection="{ fileNames }">
+                <v-chip
+                  color="primary"
+                  size="small"
+                  class="mr-2"
+                >
+                  <v-icon start>mdi-image</v-icon>
+                  {{ fileNames[0] }}
+                </v-chip>
+              </template>
+            </v-file-input>
+          </v-col>
+
+          <!-- Preview de Imagen -->
+          <v-col cols="12" md="6">
+            <div v-if="previewImagen" class="preview-container">
+              <div class="text-caption mb-2 text-medium-emphasis">Vista previa:</div>
+              <v-card variant="outlined" class="preview-card">
+                <v-img
+                  :src="previewImagen"
+                  aspect-ratio="16/9"
+                  cover
+                  class="preview-image"
+                >
+                  <template #placeholder>
+                    <div class="d-flex align-center justify-center fill-height">
+                      <v-progress-circular indeterminate color="primary"></v-progress-circular>
+                    </div>
+                  </template>
+                </v-img>
+                <v-card-actions class="pa-2">
+                  <v-spacer></v-spacer>
+                  <v-btn
+                    size="small"
+                    color="error"
+                    variant="text"
+                    @click="eliminarImagen"
+                    :disabled="cargandoFormulario"
+                  >
+                    <v-icon start>mdi-delete</v-icon>
+                    Eliminar
+                  </v-btn>
+                </v-card-actions>
+              </v-card>
+            </div>
+            <div v-else class="preview-placeholder">
+              <v-icon size="64" color="grey-lighten-2">mdi-image-off-outline</v-icon>
+              <div class="text-caption text-medium-emphasis mt-2">No hay imagen seleccionada</div>
+            </div>
           </v-col>
 
           <!-- Sección opcionales -->
@@ -231,28 +416,15 @@ onMounted(() => {
             <div class="text-subtitle-2 text-medium-emphasis mb-4">Información Adicional (Opcional)</div>
           </v-col>
 
-          <!-- Imagen URI -->
-          <v-col cols="12" md="6">
-            <v-text-field
-              v-model="formularioNoticia.imagen_uri"
-              label="URL de la imagen"
-              variant="outlined"
-              prepend-inner-icon="mdi-image"
-              :disabled="cargandoFormulario"
-              hint="URL o ruta de la imagen"
-              persistent-hint
-            ></v-text-field>
-          </v-col>
-
           <!-- Enlace Externo -->
-          <v-col cols="12" md="6">
+          <v-col cols="12">
             <v-text-field
               v-model="formularioNoticia.enlace_externo"
               label="Enlace externo"
               variant="outlined"
               prepend-inner-icon="mdi-link"
               :disabled="cargandoFormulario"
-              hint="URL para más información"
+              hint="URL para más información sobre la noticia"
               persistent-hint
             ></v-text-field>
           </v-col>
@@ -265,13 +437,14 @@ onMounted(() => {
               color="warning"
               inset
               :disabled="cargandoFormulario"
-              hint="Las noticias destacadas aparecen primero en el carrusel"
-              persistent-hint
             >
               <template #prepend>
-                <v-icon>mdi-star</v-icon>
+                <v-icon color="warning">mdi-star</v-icon>
               </template>
             </v-switch>
+            <div class="text-caption text-medium-emphasis ml-12">
+              Las noticias destacadas aparecen primero en el carrusel, independiente de su prioridad
+            </div>
           </v-col>
         </v-row>
       </v-form>
@@ -292,7 +465,7 @@ onMounted(() => {
       <v-btn
         color="primary"
         variant="elevated"
-        :loading="cargandoFormulario"
+        :loading="cargandoFormulario || subiendoImagen"
         @click="guardar"
       >
         <v-icon start>mdi-content-save</v-icon>
@@ -307,6 +480,27 @@ onMounted(() => {
   .v-card-text {
     max-height: 70vh;
     overflow-y: auto;
+  }
+
+  .preview-container {
+    .preview-card {
+      max-width: 300px;
+
+      .preview-image {
+        border-radius: 4px;
+      }
+    }
+  }
+
+  .preview-placeholder {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-height: 180px;
+    border: 2px dashed rgba(var(--v-theme-on-surface), 0.12);
+    border-radius: 4px;
+    background: rgba(var(--v-theme-surface-variant), 0.5);
   }
 }
 
@@ -325,6 +519,10 @@ onMounted(() => {
       .v-btn {
         width: 100%;
       }
+    }
+
+    .preview-container .preview-card {
+      max-width: 100%;
     }
   }
 }

--- a/src/webapp/src/views/noticias/ListaNoticias.vue
+++ b/src/webapp/src/views/noticias/ListaNoticias.vue
@@ -191,14 +191,15 @@ onMounted(() => {
 
         <template #item.orden_prioridad="{ item }">
           <v-chip
-            v-if="item.orden_prioridad > 0"
-            :color="item.orden_prioridad >= 10 ? 'error' : item.orden_prioridad >= 5 ? 'warning' : 'info'"
+            :color="item.orden_prioridad >= 10 ? 'error' : item.orden_prioridad >= 5 ? 'warning' : 'grey'"
             size="small"
             variant="flat"
           >
-            {{ item.orden_prioridad }}
+            <v-icon start size="x-small">
+              {{ item.orden_prioridad >= 10 ? 'mdi-arrow-up' : item.orden_prioridad >= 5 ? 'mdi-minus' : 'mdi-arrow-down' }}
+            </v-icon>
+            {{ item.orden_prioridad >= 10 ? 'Alta' : item.orden_prioridad >= 5 ? 'Media' : 'Baja' }}
           </v-chip>
-          <span v-else class="text-caption text-medium-emphasis">{{ item.orden_prioridad }}</span>
         </template>
 
         <template #item.estado_noticia="{ item }">


### PR DESCRIPTION
Backend:
- Crear FileStorageService: servicio para guardar imágenes en resources/static/noticias
  - Validación de formatos (PNG, JPG, WEBP, GIF)
  - Validación de tamaño máximo (5MB)
  - Creación automática de directorio si no existe
  - Nombres únicos con timestamp y UUID
- Crear FileUploadApi: endpoints para subir y eliminar imágenes
  - POST /api/archivo/noticia/imagen (upload)
  - DELETE /api/archivo/noticia/imagen (delete)

Frontend:
- Modificar FormularioNoticia.vue:
  - Agregar v-file-input con preview de imagen
  - Preview antes de subir con opción de eliminar
  - Subida automática al guardar noticia
  - Validación de formatos en cliente
  - Cambiar orden_prioridad a selector visual (Alta/Media/Baja)

- Modificar ListaNoticias.vue:
  - Mostrar prioridad con etiquetas visuales (Alta/Media/Baja)
  - Chips con iconos y colores según prioridad

Mapeo de prioridad:
- Baja = 0 (gris, flecha abajo)
- Media = 5 (amarillo, línea)
- Alta = 10 (rojo, flecha arriba)